### PR TITLE
fix(cd): huskyインストールCI対応 - prepare スクリプト修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: 依存関係のインストール
         run: npm ci
+        env:
+          HUSKY: 0
 
       - name: データベースマイグレーション実行
         run: npm run migrate:latest
@@ -83,6 +85,8 @@ jobs:
           echo "本番用の依存関係のみでビルド検証..."
           npm ci --omit=dev
           echo "✅ ビルド検証成功"
+        env:
+          HUSKY: 0
 
   # ========================================
   # Job 2: バージョン管理とタグ作成

--- a/backend/__tests__/unit/routes/login.test.js
+++ b/backend/__tests__/unit/routes/login.test.js
@@ -420,7 +420,6 @@ describe('Login Routes', () => {
     });
   });
 
-
   describe('GET /auth/me with full_name', () => {
     let appWithFullName;
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "backup": "./scripts/backup.sh",
     "restore": "./scripts/restore.sh",
     "docs:postman": "node scripts/generate-postman-collection.js",
-    "prepare": "husky install"
+    "prepare": "husky install || true"
   },
   "lint-staged": {
     "backend/**/*.js": [


### PR DESCRIPTION
## 問題\n\nGitHub Actions の CD Pipeline で `npm ci` 実行時に以下のエラーが発生:\n```\nnpm error code 127\nnpm error command failed\nnpm error command sh -c husky install\n```\nCI環境にhuskyがインストールされていない場合、`prepare`スクリプトが失敗する。\n\n## 修正内容\n\n### package.json\n- `prepare` スクリプトを `husky install || true` に変更\n- CI環境でhuskyが見つからない場合もエラーを無視してスキップ\n\n### .github/workflows/cd.yml\n- `npm ci` ステップに `HUSKY: 0` 環境変数を追加\n- huskyのpost-installフックをCI環境で完全に無効化\n\n## 検証\n`HUSKY=0 npm ci` が正常に完了することを確認済み。