### PR TITLE
fix(security): TOTP_ENCRYPTION_KEY をGitHub Secretsに移行・CD Pipeline強化

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,13 +77,14 @@ jobs:
         run: npm test
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET_TEST }}
+          TOTP_ENCRYPTION_KEY: ${{ secrets.TOTP_ENCRYPTION_KEY }}
           NODE_ENV: test
           DATABASE_PATH: ./backend/test_itsm.db
 
       - name: 本番用ビルド検証
         run: |
           echo "本番用の依存関係のみでビルド検証..."
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           echo "✅ ビルド検証成功"
         env:
           HUSKY: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
   NODE_ENV: test
   DATABASE_PATH: ./backend/test_itsm.db
   ENABLE_HTTPS: false  # CI環境ではHTTPモードを使用（SSL証明書不要）
-  TOTP_ENCRYPTION_KEY: 09x4Lcs0dDCExE9UKm8FtvGUP8pJBDp9/rRLzHW664U=  # テスト用固定キー（32バイトbase64）
+  TOTP_ENCRYPTION_KEY: ${{ secrets.TOTP_ENCRYPTION_KEY }}
 
 # 同時実行制御 - 同じブランチでは最新のみ実行
 concurrency:


### PR DESCRIPTION
## 概要
TOTP_ENCRYPTION_KEY をci.ymlのハードコードからGitHub Secretsに安全に移行します。

## 変更内容

### セキュリティ修正 (Issue #9関連)
- `.github/workflows/ci.yml`: TOTP_ENCRYPTION_KEYをハードコードから`${{ secrets.TOTP_ENCRYPTION_KEY }}`に変更
- GitHub Secrets: `TOTP_ENCRYPTION_KEY` を登録済み

### CD Pipeline安定化
- `.github/workflows/cd.yml`: テストステップにTOTP_ENCRYPTION_KEY Secretを追加
- `.github/workflows/cd.yml`: 本番ビルド検証に`--ignore-scripts`追加（huskyの完全回避）

## テスト
- CI Pipeline通過確認予定
- ユニット・統合テスト全通過済み

## 関連Issue
- Closes #20 (GitHub Actions Secrets活用)