### PR TITLE
fix(cd): dotenvをdevDependenciesから削除しproduction依存に正規化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "@types/node": "^22.19.3",
         "concurrently": "^9.1.2",
         "cross-env": "^7.0.3",
-        "dotenv": "^17.2.3",
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^10.1.8",
@@ -4004,7 +4003,6 @@
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
       "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@types/node": "^22.19.3",
     "concurrently": "^9.1.2",
     "cross-env": "^7.0.3",
-    "dotenv": "^17.2.3",
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## 問題
CD Pipelineの「データベースマイグレーション実行」ステップが失敗していた。

**エラー**: `Cannot find module 'dotenv'`

## 根本原因
`package-lock.json`で`dotenv`が`"dev": true`に設定されており、`npm ci`後にマイグレーション実行時に解決できなかった。

`knexfile.js`では`require('dotenv').config()`が使用されており、これは本番実行時にも必要な依存関係。

## 修正内容
- `package.json`の`devDependencies`から`dotenv`を削除（`dependencies`には残す）
- `package-lock.json`を再生成（`dotenv`が`"dev": false`になった）

## 確認
- `dotenv`はv17.2.3、`dependencies`に残存
- `package-lock.json`の`node_modules/dotenv`に`"dev"`フィールドなし