### PR TITLE
fix(cd): npm ciステップでNODE_ENV=developmentを設定しdev依存関係をインストール

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,7 @@ jobs:
         run: npm ci
         env:
           HUSKY: 0
+          NODE_ENV: development
 
       - name: データベースマイグレーション実行
         run: npm run migrate:latest


### PR DESCRIPTION
## 問題
CD Pipelineの「Lint チェック」ステップが `eslint: not found` で失敗していた。

## 根本原因
ワークフローのグローバル環境変数で `NODE_ENV: production` が設定されており、
これにより `npm ci` が `devDependencies`（eslint, jest等）をスキップしていた。

npmの仕様: `NODE_ENV=production` 環境では `npm ci` は `--omit=dev` と同様に動作する。

## 修正内容
`npm ci` ステップに `NODE_ENV: development` を明示的に設定して、
全依存関係（devDependencies含む）がインストールされるようにした。

- グローバルの `NODE_ENV: production` は維持（本番用ビルド検証ステップで必要）
- 初期インストールステップのみ `development` に上書き