### PR TITLE
fix(cd): ワークフローにcontents:write権限を追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,11 @@ on:
 env:
   NODE_ENV: production
 
+# ワークフロー権限設定
+permissions:
+  contents: write   # package.jsonバージョン更新・タグ作成・Release作成に必要
+  packages: write   # パッケージ公開に必要
+
 # 同時実行制御 - デプロイは1つずつ実行
 concurrency:
   group: cd-${{ github.ref }}


### PR DESCRIPTION
## 問題
CD Pipelineの「バージョンタグ作成」ジョブが権限エラーで失敗。

```
remote: Permission to Kensan196948G/ITSM-System.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

## 原因
`github-actions[bot]` がリポジトリへのpush権限を持っていなかった。
このジョブでは:
- `npm version` でpackage.jsonを更新
- `git push` でmainブランチにプッシュ
- `git tag` でバージョンタグを作成

これらの操作には `contents: write` 権限が必要。

## 修正
ワークフローレベルに `permissions: contents: write` を追加。