### PR TITLE
feat(frontend): ES Modulesエントリポイント追加・後方互換性維持

### DIFF
--- a/frontend/core/auth.js
+++ b/frontend/core/auth.js
@@ -1,0 +1,29 @@
+/**
+ * ITSM-Sec Nexus - 認証ユーティリティ（ES Module）
+ *
+ * api-client.jsの401エラーハンドリングから動的インポートされます。
+ * app.jsの認証ロジックとの橋渡しを担います。
+ */
+
+/**
+ * 認証エラー発生時の処理（401 Unauthorized）
+ * app.jsの既存ログアウト処理を呼び出すか、直接リダイレクトします。
+ */
+export function handleUnauthorized() {
+  // app.jsにlogout関数がグローバル定義されていれば呼び出す
+  if (typeof window.logout === 'function') {
+    window.logout();
+  } else {
+    // フォールバック: ストレージクリアしてログインページへリダイレクト
+    try {
+      localStorage.removeItem('itsm_auth_token');
+      localStorage.removeItem('itsm_user_info');
+      localStorage.removeItem('itsm_token_expiry');
+      sessionStorage.clear();
+    } catch (e) {
+      // ストレージアクセスエラーは無視
+    }
+    // ページリロードでログイン画面を表示（SPA設計のためリダイレクトは不要）
+    window.dispatchEvent(new CustomEvent('itsm:unauthorized'));
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -299,6 +299,8 @@
     <script src="https://cdn.jsdelivr.net/npm/i18next@23.7.6/i18next.min.js"></script>
     <script src="utils/tableUtils.js"></script>
     <script src="i18n.js"></script>
+    <!-- ES Modules エントリポイント（app.jsより先にロード） -->
+    <script type="module" src="main.js"></script>
     <script src="app.js?v=4.4"></script>
 </body>
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,79 @@
+/**
+ * ITSM-Sec Nexus - ES Modules エントリポイント
+ *
+ * このファイルはESモジュールシステムのエントリポイントです。
+ * 各モジュールをインポートしてグローバルに公開することで、
+ * 既存のapp.js（レガシーグローバルスコープ）との後方互換性を維持しながら
+ * モジュール化を段階的に進めます。
+ *
+ * 移行戦略:
+ * 1. このファイルでモジュールをインポートしてグローバル公開（現在）
+ * 2. app.jsの関数を徐々にモジュールに移行（将来）
+ * 3. app.jsを段階的に縮小・廃止（最終目標）
+ */
+
+// ===== Core Modules =====
+import { ApiClient, apiClient } from './core/api-client.js';
+
+// ===== Shared UI Modules =====
+import { Toast } from './shared/ui/toast.js';
+import {
+  createEl,
+  clearElement,
+  setText,
+  createBadge,
+  createLoadingSpinner,
+  createErrorMessage
+} from './shared/ui/dom-utils.js';
+
+// ===== Feature Modules =====
+import { renderKpiCards } from './features/dashboard/kpi-cards.js';
+
+// ===== Config =====
+import {
+  API_BASE,
+  TOKEN_KEY,
+  USER_KEY,
+  TOKEN_EXPIRY_KEY,
+  CHART_COLORS,
+  STATUS_COLORS,
+  PRIORITY_COLORS,
+  SEVERITY_COLORS
+} from './config/constants.js';
+
+// ===== グローバル公開（後方互換性のため） =====
+// app.jsおよびその他のスクリプトがグローバルアクセスできるよう公開
+window.__itsmModules = {
+  // Core
+  ApiClient,
+  apiClient,
+
+  // UI
+  Toast,
+
+  // DOM Utilities
+  createEl,
+  clearElement,
+  setText,
+  createBadge,
+  createLoadingSpinner,
+  createErrorMessage,
+
+  // Features
+  renderKpiCards,
+
+  // Config
+  API_BASE,
+  TOKEN_KEY,
+  USER_KEY,
+  TOKEN_EXPIRY_KEY,
+  CHART_COLORS,
+  STATUS_COLORS,
+  PRIORITY_COLORS,
+  SEVERITY_COLORS
+};
+
+// デバッグ用: モジュールロード完了通知
+if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+  console.log('[ITSM Modules] ES Modules loaded successfully', Object.keys(window.__itsmModules));
+}


### PR DESCRIPTION
## 概要

Issue #21 対応: フロントエンドES Modules化の基盤整備

## 変更内容

### `frontend/main.js`（新規作成）
- ESモジュールシステムのエントリポイント
- 既存モジュールをインポートして `window.__itsmModules` でグローバル公開
- 対象: ApiClient, Toast, DOM Utilities, KPI Cards, Config定数
- **後方互換性維持**: app.jsのグローバル関数は引き続き動作

### `frontend/core/auth.js`（新規作成）
- api-client.jsが動的インポートする認証ユーティリティ
- 401エラー時に `window.logout()` を呼び出すか `itsm:unauthorized` イベント発火
- app.jsとの連携ブリッジ

### `frontend/index.html`（修正）
- `<script type="module" src="main.js">` を追加
- app.jsより前にロードして依存関係を解決

## 移行戦略

```
現在: app.js（18638行・グローバルスコープ）＋ ESモジュール基盤
次期: app.jsの関数を徐々にモジュールに移行
最終: app.jsを段階的に縮小・廃止
```

## Closes
- Closes #21