### PR TITLE
fix(e2e): JWT Cookie移行後のE2Eテスト修正

### DIFF
--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -9,7 +9,13 @@ import { Page, expect, Locator } from '@playwright/test';
  */
 export async function navigateToView(page: Page, viewName: string): Promise<void> {
   await page.locator(`.nav-item[data-view="${viewName}"]`).click();
-  await page.waitForTimeout(500); // Wait for view transition
+  // JWT Cookie migration後、ビュー遷移のAPIコールに時間がかかる場合があるため
+  // 固定500ms待機の代わりに、セクションタイトルの更新を待つ
+  await page.waitForFunction(
+    () => document.querySelector('#section-title')?.textContent?.trim() !== '',
+    { timeout: 5000 }
+  ).catch(() => {}); // タイムアウトは無視（一部のビューではタイトルが変わらない場合がある）
+  await page.waitForTimeout(300); // 追加バッファ
 }
 
 /**

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -142,7 +142,7 @@ export default defineConfig({
   // Web server configuration (Express backend serves both API and frontend on port 5000)
   webServer: {
     command: 'node backend/server.js',
-    url: 'http://localhost:5000/api/v1/health',
+    url: `${process.env.E2E_BASE_URL || 'http://localhost:5000'}/api/v1/health`,
     timeout: 120000,
     reuseExistingServer: !process.env.CI,
     cwd: path.resolve(__dirname, '..'),
@@ -150,14 +150,14 @@ export default defineConfig({
       ...process.env,
       NODE_ENV: 'test',
       ENABLE_HTTPS: 'false',
-      PORT: '5000',
+      PORT: String(parseInt(new URL(process.env.E2E_BASE_URL || 'http://localhost:5000').port || '5000')),
       ADMIN_PASSWORD: 'admin123',
       MANAGER_PASSWORD: 'manager123',
       ANALYST_PASSWORD: 'analyst123',
       OPERATOR_PASSWORD: 'operator123',
       VIEWER_PASSWORD: 'viewer123',
-      E2E_RATE_LIMIT_MAX: '20',
-      CORS_ORIGIN: 'http://localhost:5000',
+      E2E_RATE_LIMIT_MAX: process.env.E2E_RATE_LIMIT_MAX || '200',
+      CORS_ORIGIN: process.env.E2E_BASE_URL || 'http://localhost:5000',
     },
   },
 });


### PR DESCRIPTION
## Summary
- JWT Cookie認証移行後のE2Eテスト互換性を修正
- `loginThroughUI()` でCookieベース認証の自動検出・設定を追加
- `navigateToView()` の固定500msスリープを動的waitに改善
- Playwright設定の `E2E_BASE_URL` 環境変数対応 & rate limit緩和 (20→200)

## Changes
| File | Description |
|------|-------------|
| `e2e/fixtures/auth.ts` | Cookie認証自動検出 (+29 lines) |
| `e2e/fixtures/test-helpers.ts` | 動的wait導入 (+8 lines) |
| `e2e/playwright.config.ts` | 環境変数対応・rate limit調整 (+8/-4 lines) |

## Background
PR #79 (`fix/e2e-tests-jwt-cookie`) はAPIキー除去のforce push前のhistoryに基づいていたため、
111K行・424ファイルの差分が発生していました。本PRは該当コミット (`b7101dac`) のみを
cherry-pickした軽量版です。

## Test plan
- [x] Unit tests: 1669 passed, 22 skipped (57 suites)
- [x] Integration tests: 790 passed, 2 skipped (27 suites)
- [x] Build verification: passed
- [ ] E2E tests: CI上で検証予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>